### PR TITLE
Pre-populate 0 amount in the form

### DIFF
--- a/app/views/deposit/collection/_invoices_table.html.erb
+++ b/app/views/deposit/collection/_invoices_table.html.erb
@@ -44,7 +44,7 @@ $(document).ready(function() {
         }
       ],
     createdRow: function(row, data, dataIndex) {
-      var disabled = parseFloat(data[3]) == 0 ? ' disabled' : '';
+      var disabled = data[3].replace(/\D/g, '') == 0 ? ' disabled' : '';
       $('td', row).eq(4).html('<input class="payment_amount_invoice" type="number" name="payment_amount_' + data[0] + '" id="payment_amount_' + dataIndex + '" value="0" step="any" class="form-control"' + disabled + '>')
     },
     drawCallback: function() {

--- a/app/views/deposit/collection/_invoices_table.html.erb
+++ b/app/views/deposit/collection/_invoices_table.html.erb
@@ -44,7 +44,7 @@ $(document).ready(function() {
         }
       ],
     createdRow: function(row, data, dataIndex) {
-      var disabled = data[3] == 0 ? ' disabled' : '';
+      var disabled = parseFloat(data[3]) == 0 ? ' disabled' : '';
       $('td', row).eq(4).html('<input class="payment_amount_invoice" type="number" name="payment_amount_' + data[0] + '" id="payment_amount_' + dataIndex + '" value="0" step="any" class="form-control"' + disabled + '>')
     },
     drawCallback: function() {

--- a/app/views/deposit/collection/_invoices_table.html.erb
+++ b/app/views/deposit/collection/_invoices_table.html.erb
@@ -44,7 +44,8 @@ $(document).ready(function() {
         }
       ],
     createdRow: function(row, data, dataIndex) {
-      $('td', row).eq(4).html('<input class="payment_amount_invoice" type="number" name="payment_amount_' + data[0] + '" id="payment_amount_' + dataIndex + '" step="any" class="form-control">')
+      var disabled = data[3] == 0 ? ' disabled' : '';
+      $('td', row).eq(4).html('<input class="payment_amount_invoice" type="number" name="payment_amount_' + data[0] + '" id="payment_amount_' + dataIndex + '" value="0" step="any" class="form-control"' + disabled + '>')
     },
     drawCallback: function() {
       $('input').change(function() {

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -10,19 +10,4 @@ class NavigationTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'test_payment_amount_field_behavior' do
-    # Simulate AJAX call to account_invoices route
-    get account_invoices_path, xhr: true
-    mock_invoices = JSON.parse(@response.body)
-    mock_payments = [Payment.new(amount: 0), Payment.new(amount: 10)]
-
-    # Simulate a GET request to the deposit page
-    get '/deposit'
-
-    # Check the response for the expected behavior of the payment amount input field
-    assert_select 'input.payment_amount_invoice', count: 2
-    assert_select 'input.payment_amount_invoice[disabled]', count: 1
-    assert_select 'input.payment_amount_invoice:not([disabled])', count: 1
-    assert_select 'input.payment_amount_invoice[value="0"]', count: 2
-  end
 end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -9,5 +9,4 @@ class NavigationTest < ActionDispatch::IntegrationTest
     get '/deposit'
     assert_response :success
   end
-
 end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -11,8 +11,9 @@ class NavigationTest < ActionDispatch::IntegrationTest
   end
 
   test 'test_payment_amount_field_behavior' do
-    # Create mock invoices and mock payments
-    mock_invoices = [Invoice.new(balance: 0), Invoice.new(balance: 10)]
+    # Simulate AJAX call to account_invoices route
+    get account_invoices_path, xhr: true
+    mock_invoices = JSON.parse(@response.body)
     mock_payments = [Payment.new(amount: 0), Payment.new(amount: 10)]
 
     # Simulate a GET request to the deposit page

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -9,4 +9,19 @@ class NavigationTest < ActionDispatch::IntegrationTest
     get '/deposit'
     assert_response :success
   end
+
+  test 'test_payment_amount_field_behavior' do
+    # Create mock invoices and mock payments
+    mock_invoices = [Invoice.new(balance: 0), Invoice.new(balance: 10)]
+    mock_payments = [Payment.new(amount: 0), Payment.new(amount: 10)]
+
+    # Simulate a GET request to the deposit page
+    get '/deposit'
+
+    # Check the response for the expected behavior of the payment amount input field
+    assert_select 'input.payment_amount_invoice', count: 2
+    assert_select 'input.payment_amount_invoice[disabled]', count: 1
+    assert_select 'input.payment_amount_invoice:not([disabled])', count: 1
+    assert_select 'input.payment_amount_invoice[value="0"]', count: 2
+  end
 end


### PR DESCRIPTION
Originally created by [@sweep-ai](https://github.com/apps/sweep-ai) here: https://github.com/pierre/killbill-deposit-ui/pull/3

/cc @travisirby: GPT-4 got the code right, writing the test was too hard though 😅 

---

### Description
This PR addresses the issue [#3](https://github.com/killbill/killbill-deposit-ui/issues/3) by modifying the `_invoices_table.html.erb` view. The changes include setting the default value of the payment amount input field to 0 and disabling it if the invoice balance is 0.

### Summary of Changes
- Modified `app/views/deposit/collection/_invoices_table.html.erb` to set the default value of the payment amount input field to 0 and disable it if the invoice balance is 0.

Fixes #3.