### PR TITLE
Rename killbill-assest-ui to killbill_assets_ui

### DIFF
--- a/app/controllers/deposit/collection_controller.rb
+++ b/app/controllers/deposit/collection_controller.rb
@@ -110,7 +110,7 @@ module Deposit
       pages ||= []
 
       # Until we support server-side sorting
-      ordering = ((params[:order] || {})[:'0'] || {})
+      ordering = (params[:order] || {})[:'0'] || {}
       ordering_column = (ordering[:column] || 0).to_i
       ordering_dir = ordering[:dir] || 'asc'
       unless search_key.nil?

--- a/lib/deposit/engine.rb
+++ b/lib/deposit/engine.rb
@@ -9,7 +9,7 @@
 
 require 'money-rails'
 require 'killbill_client'
-require 'killbill-assets-ui'
+require 'killbill_assets_ui'
 
 module Deposit
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Rename killbill-assest-ui to killbill_assets_ui.
Related PR: https://github.com/killbill/killbill-assets-ui/pull/8/files